### PR TITLE
fix typo

### DIFF
--- a/docs/why-typescript.md
+++ b/docs/why-typescript.md
@@ -161,7 +161,7 @@ var inc = x => x + 1
 이것을 벗어나서 우리는 타입스크립트의 핵심세부사항들을 파헤칠 수 있습니다.
 
 [](Interfaces are open ended)
-[](Type Inferernce rules)
+[](Type Inference rules)
 [](Cover all the annotations)
 [](Cover all ambients : also that there are no runtime enforcement)
 [](.ts vs. .d.ts)


### PR DESCRIPTION
영문오타를 발견하여 수정하였습니다. (Inferernce -> Inference)

원문에도 동일한 오타가 있었고 아래의 PR에서 수정되었습니다.(마지막 부분에 있습니다.)

추가적으로, 해당 PR에 있는 다른 오타들은 아직 살펴보지 못했습니다.

https://github.com/basarat/typescript-book/commit/9b2860c997ca348548394c2ad295ca7fd45921f6