### PR TITLE
:adhesive_bandage: Fix typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
--   [타입사크립트 시작하기](#getting-started-with-typescript)
+-   [타입스크립트 시작하기](#getting-started-with-typescript)
 -   [타입스크립트 버전](#typescript-version)
 
 # 타입스크립트 시작하기


### PR DESCRIPTION
안녕하세요? 

타입스크립트 딥다이브 잘 보고있습니다.
첫 화면에 떡하니 오타가 있어서 성격상 고치고 싶네요 🤣

사실 마크다운 헤딩으로 보면(#, ##) 목차가 다음과 같이 되어있어야 되지 않나...하는 생각도듭니다.
```markdown
- [타입스크립트 시작하기](#타입스크립트-시작하기)
  - [타입스크립트 버전](#타입스크립트-버전)
  - [소스코드 가져오기](#소스코드-가져오기)
```

일단 오타 정정 PR남깁니다. 괜찮으시다면 목차에 관련해서 의견 주세요.
좋은 하루 되세요~