### PR TITLE
Fix translation

### DIFF
--- a/docs/why-typescript.md
+++ b/docs/why-typescript.md
@@ -84,7 +84,7 @@ iTakePoint2D(point3D) // extra information okay
 iTakePoint2D({ x: 0 }) // Error: missing information `y`
 ```
 
-### 타입 에러 발생시 자바스크립트를 반환하지 않음
+### 타입 에러 발생 시 자바스크립트를 반환하는 것을 막지 않습니다.
 
 자바스크립트 코드를 쉽게 타입스크립트 코드로 마이그레이션 할수 있도록 합니다, 컴파일 오류가 있더라도 타입스크립트는 자바스크립트 코드를 최대한 반환합니다.
 


### PR DESCRIPTION
안녕하세요!

책을 읽던 중에 소제목이랑 본문 내용이 일치하지 않아서 원문을 보니 반대로 번역된 부분이 있어서 수정했습니다.

### 원문
[Type errors do not prevent JavaScript emit ](https://basarat.gitbook.io/typescript/getting-started/why-typescript#type-errors-do-not-prevent-javascript-emit)

### 번역
[타입 에러 발생시 자바스크립트를 반환하지 않음](https://radlohead.gitbook.io/typescript-deep-dive/getting-started/why-typescript#undefined-6) -> 타입 에러 발생 시 자바스크립트를 반환하는 것을 막지 않습니다.

감사합니다!